### PR TITLE
Logging fix

### DIFF
--- a/net.intolerable.appliances/internal/Confirm-DNS.ps1
+++ b/net.intolerable.appliances/internal/Confirm-DNS.ps1
@@ -32,7 +32,7 @@ Function Confirm-DNS {
 	# Whether or not to validate DNS entries 
 	switch ($ValidateDns) {
 		$false { 
-			Write-Verbose -Message (Get-FormattedTimeStamp) "DNS Validation has been disabled for this appliance provisioning operation. Confirmation of both forward and reverse lookup records will be skipped." 
+			Write-Verbose -Message (Get-FormattedMessage) "DNS Validation has been disabled for this appliance provisioning operation. Confirmation of both forward and reverse lookup records will be skipped." 
 			break
 		}
 

--- a/net.intolerable.appliances/internal/Confirm-VM.ps1
+++ b/net.intolerable.appliances/internal/Confirm-VM.ps1
@@ -7,7 +7,7 @@ Function Confirm-VM {
 	# Setting the name of the function and invoking opening verbose logging message
 	Write-Verbose -Message (Get-FormattedMessage -Message "$($MyInvocation.MyCommand) Started execution")
 
-	if ($AllowClobber -eq $true) { Write-Warning -Message (Get-FormattedTimeStamp) "The 'AllowClobber' parameter has been set to 'True'. If a virtual machine with the requested name is discovered, it will automatically be destroyed." }
+	if ($AllowClobber -eq $true) { Write-Warning -Message (Get-FormattedMessage) "The 'AllowClobber' parameter has been set to 'True'. If a virtual machine with the requested name is discovered, it will automatically be destroyed." }
 
 	# Checking whether there is a virtual machine with this name in the inventory of all currently connected vCenter servers
 	$vm = Get-VM -Name $Name -ErrorAction SilentlyContinue


### PR DESCRIPTION
Fixed incorrect verbose logging message for `Get-FormattedTimestamp` to `Get-FormattedMessage` in `Confirm-DNS` and `Confirm-VM`